### PR TITLE
Release 0.7.0

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -19,8 +19,9 @@ You need then to update in **UDV**:
 
 After that, update authentication information in **UDV-Recording** section:
 
-- citrix_login to the login on portal
-- citrix_password to the password on portal
+- citrix_login to user login used in Citrix Portal
+- citrix_password to the user's login password
+- citrix_domain to the domain used for the login process
 
 **Note:** Since JMeter 5.1, the new parameterized template will make this step optional as those 4 fields will be required 
 on template creation. 

--- a/PRE_REQUISITES.md
+++ b/PRE_REQUISITES.md
@@ -135,19 +135,6 @@ If running JMeter on virtual machines, check that you're dedicating memory and p
 
 *Ensure that you are working with supported versions of your Citrix server.*
 
-#### Disable the desktop toolbar
-
-The Citrix administrator should disable the desktop toolbar. 
-There are several ways to do this: 
-
-- Add to the default.ica file:
-
-    ConnectionBar=0 
- 
-- Follow the method described in: 
-
-   -https://support.citrix.com/article/CTX138928. (Relevant only for published desktops, not published applications).
-
 #### Session Disconnect
 
 By default, when a client times out or disconnects from the Citrix server, the session remains open for a defined time period. 
@@ -157,17 +144,6 @@ Therefore, the Citrix server administrator should configure the Citrix server to
 #### Multi-Session Support
 
 If you are going to run more than one Citrix Session on JMeter, ensure that the Citrix server is configured to enable multiple sessions per user/client.
-
-#### Run Citrix application in **non-seamless** mode, use **Windowed Mode** instead
-
-See:
-
-- https://docs.citrix.com/en-us/storefront/current-release/user-access/windowed-mode.html
-
-To check this is in place, when you launch the Citrix application manually, the Citrix Window should appear explicitely.
-You can also check that the ica file contains:
-
-    TWIMode=off
 
 #### Avoid production environments if possible
 Try to load test Citrix applications which are restricted to a few Citrix servers in a Citrix development or test environment rather than load testing in a live Citrix production environment.

--- a/citrix-client-win/pom.xml
+++ b/citrix-client-win/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.blazemeter.jmeter</groupId>
         <artifactId>citrix-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
     <artifactId>citrix-client-win</artifactId>
 

--- a/citrix-client-win/src/main/java/com/blazemeter/jmeter/citrix/client/windows/WinCitrixClient.java
+++ b/citrix-client-win/src/main/java/com/blazemeter/jmeter/citrix/client/windows/WinCitrixClient.java
@@ -324,7 +324,7 @@ public class WinCitrixClient extends AbstractCitrixClient {
       }
 
       if (waitUserLogoff(getLogoffTimeoutInMs())) {
-        LOGGER.error("Timed out waiting for Logoff");
+        LOGGER.warn("Timed out waiting for Logoff");
         sessionCookie = null;
       }
     }
@@ -334,7 +334,7 @@ public class WinCitrixClient extends AbstractCitrixClient {
         LOGGER.debug("Disconnecting ICA client");
         icaClient.disconnect();
         if (waitDisconnect(getDisconnectTimeoutInMs())) {
-          LOGGER.error("Timed out waiting for Disconnect");
+          LOGGER.warn("Timed out waiting for Disconnect");
         }
       }
     } catch (Exception e) {

--- a/citrix-common/pom.xml
+++ b/citrix-common/pom.xml
@@ -7,7 +7,26 @@
 	<parent>
 		<groupId>com.blazemeter.jmeter</groupId>
 		<artifactId>citrix-parent</artifactId>
-		<version>0.6.0</version>
+		<version>0.7.0</version>
 	</parent>
+	<dependencies>
+		<dependency>
+			<groupId>net.java.dev.jna</groupId>
+			<artifactId>jna</artifactId>
+			<version>5.6.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>net.java.dev.jna</groupId>
+			<artifactId>jna-platform</artifactId>
+			<version>5.6.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.ini4j</groupId>
+			<artifactId>ini4j</artifactId>
+			<version>0.5.4</version>
+		</dependency>
+	</dependencies>
     <artifactId>citrix-common</artifactId>
 </project>

--- a/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/Win32Utils.java
+++ b/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/Win32Utils.java
@@ -1,0 +1,52 @@
+package com.blazemeter.jmeter.citrix.client;
+
+import static com.sun.jna.platform.win32.WinUser.MAPVK_VK_TO_VSC;
+
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.WinDef;
+import java.awt.event.KeyEvent;
+
+public class Win32Utils {
+
+  public static int getVirtualKey(int keyCode) {
+    // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-vkkeyscanexw
+    WinDef.HKL keyLayoutID = User32.INSTANCE.GetKeyboardLayout(0);
+    return User32.INSTANCE.VkKeyScanExW((char) keyCode, keyLayoutID);
+  }
+
+  public static char getVKCharacter(int vkCode, boolean vkShift, boolean vkAlt, boolean vkCtrl) {
+
+    //https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getkeyboardlayout
+    int currentThread = 0;
+    WinDef.HKL keyLayoutID = User32.INSTANCE.GetKeyboardLayout(currentThread);
+
+    // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-mapvirtualkeyexa
+    int scanCode = User32.INSTANCE.MapVirtualKeyEx(vkCode, MAPVK_VK_TO_VSC, keyLayoutID);
+
+    // https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-tounicodeex
+    byte[] keyStates = new byte[256];
+    byte keyDownState = (byte) 128;
+    keyStates[KeyEvent.VK_SHIFT] = vkShift ? keyDownState : 0;
+    keyStates[KeyEvent.VK_ALT] = vkAlt ? keyDownState : 0;
+    keyStates[KeyEvent.VK_CONTROL] = vkCtrl ? keyDownState : 0;
+
+    char[] buff = new char[1];
+    int buffCharSize = 1;
+    int menuActiveFlag = 0;
+    int ret = User32.INSTANCE.ToUnicodeEx(
+        vkCode, scanCode, keyStates, buff, buffCharSize, menuActiveFlag, keyLayoutID
+    );
+
+    switch (ret) {
+      case -1: //Error
+        return (char) -1;
+
+      case 0:  //No Translation
+        return (char) 0;
+
+      default: //Returning key...
+        return buff[0];
+    }
+  }
+
+}

--- a/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/events/EventHelper.java
+++ b/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/events/EventHelper.java
@@ -2,6 +2,7 @@ package com.blazemeter.jmeter.citrix.client.events;
 
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +59,12 @@ public class EventHelper {
           Integer.toBinaryString(copy));
     }
     return result;
+  }
+
+  public static String getModifiersText(final Set<Modifier> modifiers) {
+    return modifiers.stream()
+        .map(Modifier::name)
+        .collect(Collectors.joining("+"));
   }
 
   public static int fromModifiers(Set<Modifier> modifiers) {

--- a/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/events/InteractionEvent.java
+++ b/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/events/InteractionEvent.java
@@ -1,6 +1,7 @@
 package com.blazemeter.jmeter.citrix.client.events;
 
 import com.blazemeter.jmeter.citrix.client.CitrixClient;
+import com.blazemeter.jmeter.citrix.client.Win32Utils;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -88,6 +89,17 @@ public class InteractionEvent extends ClientEvent {
     return keyCode;
   }
 
+  public int getTargetKeyCode() {
+    boolean withShift = modifiers.contains(Modifier.SHIFT);
+    boolean withAlt = modifiers.contains(Modifier.ALT);
+    boolean withCtrl = modifiers.contains(Modifier.CONTROL);
+    return Win32Utils.getVKCharacter(keyCode, withShift, withAlt, withCtrl);
+  }
+
+  public String getTargetKeyCodeString() {
+    return String.valueOf((char) getTargetKeyCode());
+  }
+
   /**
    * Gets the set of key modifiers pressed during this event.
    *
@@ -140,6 +152,10 @@ public class InteractionEvent extends ClientEvent {
    */
   public Set<MouseButton> getButtons() {
     return buttons;
+  }
+
+  public String getModifiersText() {
+    return EventHelper.getModifiersText(getModifiers());
   }
 
   /**

--- a/citrix-jmeter/pom.xml
+++ b/citrix-jmeter/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.blazemeter.jmeter</groupId>
 		<artifactId>citrix-parent</artifactId>
-		<version>0.6.0</version>
+		<version>0.7.0</version>
 	</parent>
 
 	<artifactId>citrix-jmeter</artifactId>
@@ -191,6 +191,10 @@
 									<include>org.apache.pdfbox:pdfbox-tools</include>
 									<include>org.apache.pdfbox:pdfbox</include>
 									<include>org.apache.pdfbox:fontbox</include>
+									<include>com.sun.jna.platform</include>
+									<include>net.java.dev.jna:jna</include>
+									<include>net.java.dev.jna:jna-platform</include>
+									<include>org.ini4j:ini4j</include>
 								</includes>
 							</artifactSet>
 						</configuration>

--- a/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/clause/Clause.java
+++ b/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/clause/Clause.java
@@ -4,6 +4,7 @@ import com.blazemeter.jmeter.citrix.clause.strategy.check.PollingContext;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.Serializable;
+import org.apache.jmeter.engine.util.CompoundVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,6 +100,10 @@ public class Clause implements Serializable {
    */
   public final String getExpectedValue() {
     return expectedValue;
+  }
+
+  public final String getExpectedValueParametrized() {
+    return (new CompoundVariable(getExpectedValue())).execute();
   }
 
   /**

--- a/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/clause/ClauseHelper.java
+++ b/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/clause/ClauseHelper.java
@@ -173,7 +173,8 @@ public class ClauseHelper {
   }
 
   private static Predicate<String> getRegexPredicate(Clause clause) {
-    Pattern pattern = JMeterUtils.getPatternCache().getPattern(clause.getExpectedValue(),
+    Pattern pattern = JMeterUtils.getPatternCache().getPattern(
+        clause.getExpectedValueParametrized(),
         Perl5Compiler.READ_ONLY_MASK);
     return v -> JMeterUtils.getMatcher().matches(v, pattern);
   }
@@ -183,7 +184,7 @@ public class ClauseHelper {
   }
 
   private static Predicate<String> getHashHammingDistancePredicate(Clause clause) {
-    String expectedValue = clause.getExpectedValue();
+    String expectedValue = clause.getExpectedValueParametrized();
     int hashBitResolution = (isHashLegacy(expectedValue) ? LEGACY_BIT_RESOLUTION : BIT_RESOLUTION);
     return v -> (
         new Hash(
@@ -195,7 +196,7 @@ public class ClauseHelper {
   }
 
   private static Predicate<String> getEqualPredicate(Clause clause) {
-    return v -> Objects.equals(v, clause.getExpectedValue());
+    return v -> Objects.equals(v, clause.getExpectedValueParametrized());
   }
 
   public static boolean isHashClause(Clause clause) {
@@ -217,7 +218,7 @@ public class ClauseHelper {
    */
   public static Predicate<String> buildValuePredicate(Clause clause) {
     LOGGER.debug("Builds predicate for clause {} with expected value='{}'", clause.getCheckType(),
-        clause.getExpectedValue());
+        clause.getExpectedValueParametrized());
     if (clause.isUsingRegex()) {
       return getRegexPredicate(clause);
     }

--- a/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/clause/gui/ClausePanel.java
+++ b/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/clause/gui/ClausePanel.java
@@ -207,6 +207,7 @@ public class ClausePanel extends JPanel {
     pnlExpectedValue.add(chbUseRegex, gbcRelative);
 
     taExpectedValue = JSyntaxTextArea.getInstance(5, 80);
+    taExpectedValue.setLanguage("text");
     taExpectedValue.addFocusListener(new ChangeHandler());
     GridBagConstraints gbcExpectedValue = new GridBagConstraints();
     gbcExpectedValue.anchor = GridBagConstraints.LINE_START;

--- a/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/clause/strategy/format/RegularResultFormatter.java
+++ b/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/clause/strategy/format/RegularResultFormatter.java
@@ -15,19 +15,19 @@ public class RegularResultFormatter implements ResultFormatter {
     if (result.isSuccessful()) {
       if (clause.isUsingRegex()) {
         value = "'" + result.getValue() + "' matches the expecting regular expression '"
-            + clause.getExpectedValue() + "'";
+            + clause.getExpectedValueParametrized() + "'";
       } else {
         value = "'" + result.getValue() + "' is equals to the expecting value '" +
-            clause.getExpectedValue()
+            clause.getExpectedValueParametrized()
             + "'";
       }
     } else {
       if (clause.isUsingRegex()) {
         value = "'" + result.getValue() + "' does not match the expecting regular expression '"
-            + clause.getExpectedValue() + "'";
+            + clause.getExpectedValueParametrized() + "'";
       } else {
         value = "'" + result.getValue() + "' differs from the expecting value '" +
-            clause.getExpectedValue()
+            clause.getExpectedValueParametrized()
             + "'";
       }
     }

--- a/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/sampler/CitrixBaseSampler.java
+++ b/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/sampler/CitrixBaseSampler.java
@@ -13,6 +13,8 @@ import com.blazemeter.jmeter.citrix.client.events.SessionEvent.EventType;
 import com.blazemeter.jmeter.citrix.client.factory.AbstractCitrixClientFactory;
 import com.blazemeter.jmeter.citrix.sampler.SamplerRunException.ErrorCode;
 import com.blazemeter.jmeter.citrix.utils.CitrixUtils;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -239,9 +241,6 @@ public abstract class CitrixBaseSampler extends AbstractSampler {
         // Store success assessment in sample result
         result.setAssessment(assessment[0]);
 
-        // Store registered results as response message
-        result.setResponseMessage(SamplerHelper.formatResponseMessage(details, overflow[0]));
-
         // Store the last screenshot as response data
         result.setSnapshot(lastSnapshot[0]);
       }
@@ -280,10 +279,11 @@ public abstract class CitrixBaseSampler extends AbstractSampler {
     } catch (SamplerRunException ex) {
       // Store exception message in sample result
       result.setResponseCode(ex.code());
-      result.setResponseMessage(
-          ex.getMessage() + "\n" +
-              result.getResponseMessage());
-      LOGGER.error(ex.getMessage(), ex);
+      result.setResponseMessage(ex.getMessage());
+      StringWriter sw = new StringWriter();
+      ex.printStackTrace(new PrintWriter(sw));
+      result.setResponseData(sw.toString(), SampleResult.DEFAULT_HTTP_ENCODING);
+      LOGGER.error(sw.toString(), ex);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       result.setResponseCode(CitrixUtils.getResString("base_sampler_interrupted", false));

--- a/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/sampler/gui/InteractionSamplerGUI.java
+++ b/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/sampler/gui/InteractionSamplerGUI.java
@@ -278,6 +278,7 @@ public class InteractionSamplerGUI extends CitrixSamplerGUI { // NOSONAR
   private JPanel createInputTextTab() {
     JPanel panel = new JPanel(new BorderLayout());
     taInputText = JSyntaxTextArea.getInstance(13, 120);
+    taInputText.setLanguage("text");
     panel.add(JTextScrollPane.getInstance(taInputText, true), BorderLayout.NORTH);
     return panel;
   }

--- a/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/bzmCitrixTemplateWithParameters.xml
+++ b/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/bzmCitrixTemplateWithParameters.xml
@@ -25,6 +25,7 @@
             <parameter defaultValue="Citrix Application you want to record" key="citrixApplicationName"/>
             <parameter defaultValue="Citrix Portal Login" key="citrixLogin"/>
             <parameter defaultValue="Citrix Portal Password" key="citrixPassword"/>
+            <parameter defaultValue="Citrix Portal Login Domain" key="citrixDomain"/>
             <parameter defaultValue="citrix-recording.xml" key="citrixRecordingOutputFile"/>
         </parameters>
 	</template>

--- a/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/citrixRecordingTemplate.jmx
+++ b/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/citrixRecordingTemplate.jmx
@@ -58,6 +58,11 @@
             <stringProp name="Argument.value"></stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="citrix_domain" elementType="Argument">
+            <stringProp name="Argument.name">citrix_domain</stringProp>
+            <stringProp name="Argument.value"></stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -743,6 +748,13 @@
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
                       <stringProp name="Argument.name">StateContext</stringProp>
                       <stringProp name="Argument.value"></stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                    </elementProp>
+                    <elementProp name="domain" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.name">domain</stringProp>
+                      <stringProp name="Argument.value">${citrix_domain}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>

--- a/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/citrixRecordingTemplateWithParameters.jmx
+++ b/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/citrixRecordingTemplateWithParameters.jmx
@@ -58,6 +58,11 @@
             <stringProp name="Argument.value">[=citrixPassword]</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="citrix_domain" elementType="Argument">
+            <stringProp name="Argument.name">citrix_domain</stringProp>
+            <stringProp name="Argument.value">[=citrixDomain]</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -743,6 +748,13 @@
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
                       <stringProp name="Argument.name">StateContext</stringProp>
                       <stringProp name="Argument.value"></stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                    </elementProp>
+                    <elementProp name="StateContext" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.name">domain</stringProp>
+                      <stringProp name="Argument.value">${citrix_domain}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>

--- a/citrix-jmeter/src/test/java/com/blazemeter/jmeter/citrix/assertions/TestAssertionHelper.java
+++ b/citrix-jmeter/src/test/java/com/blazemeter/jmeter/citrix/assertions/TestAssertionHelper.java
@@ -17,6 +17,8 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import javax.imageio.ImageIO;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -48,6 +50,13 @@ public class TestAssertionHelper {
     image_same_02 = loadImageResource("/hash_same_02.png");
     image_not_same_01 = loadImageResource("/hash_not_same_01.png");
     image_not_same_02 = loadImageResource("/hash_not_same_02.png");
+
+    JMeterVariables vars = new JMeterVariables();
+    vars.put("citrix", "Citrix");
+    vars.put("citrix_regex", "cITRIX");
+
+    JMeterContextService.getContext().setVariables(vars);
+
   }
 
   @Test
@@ -132,6 +141,29 @@ public class TestAssertionHelper {
     Rectangle rectangle2 = new Rectangle(new Point(1, 1), new Dimension(5000, 6000));
     ClauseHelper.hash(image_same_01, rectangle2, null);
 
+  }
+
+  @Test
+  public void testExpectedValueParametrized() {
+    Clause ocrClause = new Clause(CheckType.OCR, "Hello ${citrix}");
+    assertEquals("Hello Citrix", ocrClause.getExpectedValueParametrized());
+  }
+
+  @Test
+  public void testExpectedValueRegexParametrized() {
+    // the first letter of the var is in lowercase, the regex ignore that case
+    String clauseExpectedValue = "(?i)${citrix_regex}";
+
+    boolean useRegex = true;
+    Rectangle selection = new Rectangle(new Point(0, 0), new Dimension(50, 50));
+    Clause ocrClause = new Clause(CheckType.OCR, clauseExpectedValue, useRegex, selection);
+
+    String expectedValueParametrized = ocrClause.getExpectedValueParametrized();
+
+    String value = "CITRIX";
+    LOGGER.debug("Test regex parametrized expected value: {}, {}, {}",
+        clauseExpectedValue, expectedValueParametrized, value);
+    assertTrue(ClauseHelper.buildValuePredicate(ocrClause).test(value));
   }
 }
 

--- a/citrix-jmeter/src/test/java/com/blazemeter/jmeter/citrix/sampler/InteractionSamplerTest.java
+++ b/citrix-jmeter/src/test/java/com/blazemeter/jmeter/citrix/sampler/InteractionSamplerTest.java
@@ -1,0 +1,32 @@
+package com.blazemeter.jmeter.citrix.sampler;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import com.blazemeter.jmeter.citrix.sampler.InteractionSampler.Keystroke;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class InteractionSamplerTest {
+
+  @Test
+  public void generateKeystrokesFromText() {
+    // From written text it gets the virtual key code to be used
+    List<Keystroke> keystrokes = InteractionSampler.sampleTextKeystrokes("Ctrx");
+
+    List<Keystroke> expected = new ArrayList<>();
+    expected.add(new Keystroke(16, false, false));
+    expected.add(new Keystroke(67, false, true));
+    expected.add(new Keystroke(67, true, false));
+    expected.add(new Keystroke(16, true, false));
+    expected.add(new Keystroke(84, false, true));
+    expected.add(new Keystroke(84, true, false));
+    expected.add(new Keystroke(82, false, true));
+    expected.add(new Keystroke(82, true, false));
+    expected.add(new Keystroke(88, false, true));
+    expected.add(new Keystroke(88, true, true));
+
+    assertArrayEquals(expected.toArray(), keystrokes.toArray());
+  }
+
+}

--- a/citrix-jmeter/src/test/java/com/blazemeter/jmeter/citrix/sampler/SampleHelperTest.java
+++ b/citrix-jmeter/src/test/java/com/blazemeter/jmeter/citrix/sampler/SampleHelperTest.java
@@ -1,0 +1,58 @@
+package com.blazemeter.jmeter.citrix.sampler;
+
+import static org.junit.Assert.assertEquals;
+
+import com.blazemeter.jmeter.citrix.client.CitrixClient;
+import com.blazemeter.jmeter.citrix.client.events.EventHelper;
+import com.blazemeter.jmeter.citrix.client.events.InteractionEvent;
+import com.blazemeter.jmeter.citrix.client.events.InteractionEvent.KeyState;
+import com.blazemeter.jmeter.citrix.client.events.Modifier;
+import com.blazemeter.jmeter.citrix.client.windows.WinCitrixClient;
+import com.blazemeter.jmeter.citrix.recorder.CaptureItem;
+import java.awt.event.KeyEvent;
+import org.junit.Test;
+
+public class SampleHelperTest {
+
+  // This class is created to simplify the creation of events, just to be used in this test.
+  private static class CustomKeyCaptureGroup extends SamplerHelper.KeyCaptureGroup {
+
+    CustomKeyCaptureGroup(SamplerHelper.KeySamplerType type) {
+      super(type);
+    }
+
+    protected void  addCaptureKeyEvent(
+        CitrixClient client, int keyCode, int modifier) {
+      this.items.add(new CaptureItem(
+          new InteractionEvent(client, KeyState.KEY_DOWN, keyCode,
+              EventHelper.toModifiers(modifier)
+          )
+      ));
+      this.items.add(new CaptureItem(
+          new InteractionEvent(client, KeyState.KEY_UP, keyCode,
+              EventHelper.toModifiers(0) // Always KeyUp lost the modifier state
+          )
+      ));
+    }
+  }
+
+  @Test
+  public void generateTextFromCapturedKeyEvents() {
+    CustomKeyCaptureGroup group = new CustomKeyCaptureGroup(SamplerHelper.KeySamplerType.TEXT);
+
+    WinCitrixClient client = new WinCitrixClient();
+
+    // The test write "Ctrx" using Key Events.
+    // Use ASCII to ensure all virtual keyboard used are compatible to this
+
+    group.addCaptureKeyEvent(client, KeyEvent.VK_C, Modifier.SHIFT.getValue());
+    group.addCaptureKeyEvent(client, KeyEvent.VK_T, 0);
+    group.addCaptureKeyEvent(client, KeyEvent.VK_R, 0);
+    group.addCaptureKeyEvent(client, KeyEvent.VK_X, 0);
+
+    String text = SamplerHelper.getKeyCaptureGroupText(group);
+    String expected = "Ctrx";
+    assertEquals(expected, text);
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.blazemeter.jmeter</groupId>
     <artifactId>citrix-parent</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <packaging>pom</packaging>
     <name>Citrix Plugin for Apache JMeter</name>
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Release 0.7.0

**Enhancements:**

* Ability to specify domain to use over Storefront when more than one domain is configured on Storefront.
* JMeter variables usage support in the Expected Value field on EndClause. **Issues** https://github.com/Blazemeter/CitrixPlugin/issues/20
* Keystroke recording enhancements that allow you to record more complex keyboard combinations. **Issues** https://github.com/Blazemeter/CitrixPlugin/issues/30 https://github.com/Blazemeter/CitrixPlugin/issues/34 
* InputText allows free text writing that generate complex keystrokes combinations automatically.  **Issues**  https://github.com/Blazemeter/CitrixPlugin/issues/30 https://github.com/Blazemeter/CitrixPlugin/issues/34
* Automatic disabling of Citrix Desktop Viewer, now it is not required to modify Citrix server configuration.