### PR TITLE
Release 0.7.7

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -89,10 +89,6 @@ It is possible that due to overload the server is not managing to start a Window
 
 You can increase the timeout value by setting the [bzm.citrix.client_factory.client_property.logon_timeout_ms](SETUP.md#plugin-properties) property.
 
-##### ACTIVEAPP_TIMEOUT: Timed out waiting for Active App
-
-The application under load may not be able to start in time or there is some other problem on the server that is preventing the application from starting.
- 
 ##### START_SESSION_ERROR: Unable to start session
 
 This error is an unexpected error.

--- a/citrix-client-win/pom.xml
+++ b/citrix-client-win/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.blazemeter.jmeter</groupId>
         <artifactId>citrix-parent</artifactId>
-        <version>0.7.6</version>
+        <version>0.7.7</version>
     </parent>
     <artifactId>citrix-client-win</artifactId>
 

--- a/citrix-common/pom.xml
+++ b/citrix-common/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.blazemeter.jmeter</groupId>
 		<artifactId>citrix-parent</artifactId>
-		<version>0.7.6</version>
+		<version>0.7.7</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/AbstractCitrixClient.java
+++ b/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/AbstractCitrixClient.java
@@ -58,7 +58,7 @@ public abstract class AbstractCitrixClient implements CitrixClient {
   private Long icaFileTimeoutInMs = 10000L;
   private Long connectTimeoutInMs = 90000L;
   private Long logonTimeoutInMs = 90000L;
-  private Long activeAppTimeoutInMs = 120000L;
+  private Long activeAppTimeoutInMs = 15000L;
   private Long logoffTimeoutInMs = 65000L;
   private Long disconnectTimeoutInMs = 65000L;
   private Long socketTimeoutInMs = 5000L;

--- a/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/CitrixClient.java
+++ b/citrix-common/src/main/java/com/blazemeter/jmeter/citrix/client/CitrixClient.java
@@ -201,6 +201,10 @@ public interface CitrixClient {
 
   int getForegroundWindowID();
 
+  String getForegroundWindowCaption();
+
+  void setClientName(String clientName);
+
   class Snapshot {
     private final Rectangle fgWindowArea;
     private final BufferedImage screenshot;

--- a/citrix-jmeter/pom.xml
+++ b/citrix-jmeter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.blazemeter.jmeter</groupId>
         <artifactId>citrix-parent</artifactId>
-        <version>0.7.6</version>
+        <version>0.7.7</version>
     </parent>
 
     <artifactId>citrix-jmeter</artifactId>
@@ -333,7 +333,7 @@
         <dependency>
             <groupId>com.blazemeter</groupId>
             <artifactId>jmeter-bzm-commons</artifactId>
-            <version>0.1</version>
+            <version>0.2.1</version>
         </dependency>
         <!-- Aded to support URL validations -->
         <dependency>

--- a/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/recorder/gui/ConfigurationPanel.java
+++ b/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/recorder/gui/ConfigurationPanel.java
@@ -60,6 +60,7 @@ public class ConfigurationPanel extends BasePanel {
   private static final String CITRIX_LOGIN = "citrix_login";
   private static final String CITRIX_PASSWORD = "citrix_password";
   private static final String CITRIX_DOMAIN = "citrix_domain";
+  private static final String CITRIX_CLIENT_NAME = "citrix_client_name";
 
   private static final Validation NOT_EMPTY = new Validation(s -> !s.isEmpty(),
       "This field can't be empty");

--- a/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/sampler/CitrixBaseSampler.java
+++ b/citrix-jmeter/src/main/java/com/blazemeter/jmeter/citrix/sampler/CitrixBaseSampler.java
@@ -13,10 +13,16 @@ import com.blazemeter.jmeter.citrix.client.events.SessionEvent.EventType;
 import com.blazemeter.jmeter.citrix.client.factory.AbstractCitrixClientFactory;
 import com.blazemeter.jmeter.citrix.sampler.SamplerRunException.ErrorCode;
 import com.blazemeter.jmeter.citrix.utils.CitrixUtils;
+import com.blazemeter.jmeter.citrix.utils.TestPlanHelper;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.gui.GuiPackage;
+import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
@@ -106,7 +112,13 @@ public abstract class CitrixBaseSampler extends AbstractSampler {
       throws SamplerRunException, CitrixClientException, InterruptedException;
 
   public void initClient(CitrixClient client) {
-
+    List<String> propList = Arrays.asList("citrix_client_name");
+    Map<String, String> propSet = TestPlanHelper
+        .getArguments((JMeterTreeNode) GuiPackage.getInstance().getTreeModel().getRoot(), propList);
+    String clientName = propSet.getOrDefault("citrix_client_name", "");
+    if (!clientName.isEmpty()) {
+      client.setClientName(new CompoundVariable(clientName).execute());
+    }
   }
 
   // Instantiates a Citrix client and place it the session holder

--- a/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/citrixRecordingTemplate.jmx
+++ b/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/citrixRecordingTemplate.jmx
@@ -132,6 +132,22 @@
         </collectionProp>
       </Arguments>
       <hashTree/>
+	  <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="UDV Citrix Client Properties" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="citrix_client_name" elementType="Argument">
+            <stringProp name="Argument.name">citrix_client_name</stringProp>
+            <stringProp name="Argument.value"></stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">The identification name of the Desktop. Empty uses the default policy.</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
+        <collectionProp name="CookieManager.cookies"/>
+        <boolProp name="CookieManager.clearEachIteration">true</boolProp>
+      </CookieManager>
+      <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">stopthread</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
@@ -1040,7 +1056,7 @@ AssertionResult.setFailureMessage(error_message);
               <boolProp name="Cookie.domain_specified">true</boolProp>
             </elementProp>
           </collectionProp>
-          <boolProp name="CookieManager.clearEachIteration">false</boolProp>
+          <boolProp name="CookieManager.clearEachIteration">true</boolProp>
           <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
         </CookieManager>
         <hashTree/>

--- a/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/citrixRecordingTemplateWithParameters.jmx
+++ b/citrix-jmeter/src/main/resources/com/blazemeter/jmeter/citrix/template/citrixRecordingTemplateWithParameters.jmx
@@ -66,6 +66,17 @@
         </collectionProp>
       </Arguments>
       <hashTree/>
+	  <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="UDV Citrix Client Properties" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="citrix_client_name" elementType="Argument">
+            <stringProp name="Argument.name">citrix_client_name</stringProp>
+            <stringProp name="Argument.value"></stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">The identification name of the Desktop. Empty uses the default policy.</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
       <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
         <collectionProp name="CookieManager.cookies"/>
         <boolProp name="CookieManager.clearEachIteration">true</boolProp>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.blazemeter.jmeter</groupId>
     <artifactId>citrix-parent</artifactId>
-    <version>0.7.6</version>
+    <version>0.7.7</version>
     <packaging>pom</packaging>
     <name>Citrix Plugin for Apache JMeter</name>
 


### PR DESCRIPTION
- The ACTIVEAPP_TIMEOUT error is deprecated.
The timeout still exists, the difference is that now an error is not generated if the application is not detected.
This allows programming particular logics for those screens that are not detected or require some type of particular intervention.
Generally Logon Screen, terms and conditions acceptance screens or all those screens that are prior to the start of an application and are incorporated by the windows policies created by the administrators.

- The default active app timeout was changed to 15 seconds.

- The Citrix Client Name property as a User Defined Variable was incorporated. This allow in the Test Plan to create a particular identifier. By default Citrix use the machine name of the Desktop or the identifier forced by Citrix administrator. For some type of apps, this value need to change to simulate different machines.

- Added HTTP Cookie Manager to the Test Plan and set the value of Clear on each iteration to True, to allow to align the Download ICA file and session with the logic of the Test Plan.

- Update the dependency jmeter-bzm-commons to 0.2.1
