### PR TITLE
Add automatic jmeter plugin deployment

### DIFF
--- a/.github/workflows/publish_to_jmeter_plugins.yaml
+++ b/.github/workflows/publish_to_jmeter_plugins.yaml
@@ -1,0 +1,26 @@
+name: Deploy to JMeter Plugins
+
+on:
+  workflow_dispatch:
+    inputs:
+      changes:
+        description: 'Release notes for the update'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Publish JMeter Plugin Action
+        id: publish-plugin
+        uses: abstracta/jmeter-plugin-publish-action@main
+        with:
+          upstream-repository: https://github.com/Abstracta/jmeter-plugins.git 
+          forked-repository: https://github.com/Abstracta/jmeter-plugins.git
+          plugin-artifact-name: citrix-jmeter
+          plugin-id: bzm-jmeter-citrix-plugin
+          changes: ${{ inputs.changes }}
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Pull Request URL
+        run: echo ${{ steps.publish-plugin.outputs.pull_request }}


### PR DESCRIPTION
This github action will publish the plugin automatically to JMeter Plugins repository